### PR TITLE
Fix/auth-response

### DIFF
--- a/src/Services/UserService.ts
+++ b/src/Services/UserService.ts
@@ -33,7 +33,7 @@ export class UserService {
             const authenticatedUser = bcrypt.compareSync(password, user['hash_password']);
             if (authenticatedUser) {
                 const token = jwt.sign({id: user['id']}, config.jwtKey, {expiresIn: config.jwtExpiry});
-                return token;
+                return {token: token};
             }
             throw new ServiceError(401, "Unauthorized user.");
         }

--- a/test/unit/Services/UserService.test.ts
+++ b/test/unit/Services/UserService.test.ts
@@ -35,7 +35,7 @@ describe("UserService", function () {
                 'example@example.com',
                 'super secret password'
             );
-            expect(authenticatedUser).to.be.a('string');
+            expect(authenticatedUser).to.haveOwnProperty('token');
         } catch (err) {
             logger.error('Unexpected error occured: ${err.message}');
             expect.fail(err);


### PR DESCRIPTION
Fixed response from ```api/user/login``` to be in json format and not plain string. 
Structure now is: ```{token: "some token"}```