### PR TITLE
Feature/store-past-deals

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -13,6 +13,7 @@ import {NodeUptimeController} from "./Controller/Api/NodeUptimeController";
 import {NodeGeneralInfoController} from "./Controller/Api/NodeGeneralInfoController";
 import {MiningRewardsController} from "./Controller/Api/MiningRewardsController";
 import {NodeBalanceController} from "./Controller/Api/NodeBalanceController";
+import {NodePastDealsController} from "./Controller/Api/NodePastDealsController";
 import {UserController} from "./Controller/Api/UserController";
 import {createApiRoutes} from "./Routes/Api";
 import {Service} from "./Services/interface";
@@ -23,6 +24,7 @@ import {NodeUptimeService} from "./Services/NodeUptimeService";
 import {NodeGeneralInfoService} from "./Services/NodeGeneralInfoService";
 import {MiningRewardsService} from "./Services/MiningRewardsService";
 import {NodeBalanceService} from "./Services/NodeBalanceService";
+import {NodePastDealsService} from "./Services/NodePastDealsService";
 import {UserService} from "./Services/UserService";
 import {validateJoiError} from "./Middleware/ValidationErrorHandling";
 
@@ -52,6 +54,9 @@ export class App implements Service {
     private nodeBalanceController: NodeBalanceController;
     private nodeBalanceService: NodeBalanceService;
 
+    private nodePastDealsController: NodePastDealsController;
+    private nodePastDealsService: NodePastDealsService;
+
     constructor() {
         this.express = express();
         // add before route middleware's here
@@ -67,6 +72,7 @@ export class App implements Service {
         this.userService = new UserService();
         this.nodeGeneralInfoService = new NodeGeneralInfoService();
         this.nodeBalanceService = new NodeBalanceService();
+        this.nodePastDealsService = new NodePastDealsService();
     }
 
     public async start(): Promise<void> {
@@ -95,6 +101,7 @@ export class App implements Service {
         this.userController = new UserController(this.userService);
         this.nodeGeneralInfoController = new NodeGeneralInfoController(this.nodeGeneralInfoService);
         this.nodeBalanceController = new NodeBalanceController(this.nodeBalanceService);
+        this.nodePastDealsController = new NodePastDealsController(this.nodePastDealsService);
     }
 
     private addInitialRoutes(): void {
@@ -122,7 +129,8 @@ export class App implements Service {
             this.userController,
             this.nodeGeneralInfoController,
             this.miningRewardsController,
-            this.nodeBalanceController
+            this.nodeBalanceController,
+            this.nodePastDealsController
         ));
 
         this.express.use(validateJoiError);

--- a/src/Controller/Api/NodePastDealsController.ts
+++ b/src/Controller/Api/NodePastDealsController.ts
@@ -1,0 +1,30 @@
+import {Response} from "express";
+import {ValidatedRequest} from "express-joi-validation";
+
+import {NodePastDealsService} from "../../Services/NodePastDealsService";
+import {CreateNodePastDealsRequestSchema} from "./NodePastDealsControllerValidation";
+import logger from "../../Services/Logger";
+
+export class NodePastDealsController {
+
+    private nodePastDealsService: NodePastDealsService;
+
+    constructor(nodePastDealsService: NodePastDealsService) {
+        this.nodePastDealsService = nodePastDealsService;
+    }
+
+    public async updateOrCreatePastDeal(
+        req: ValidatedRequest<CreateNodePastDealsRequestSchema>,
+        res: Response) {
+        try {
+            const {cid, state, size, provider, price, duration} = req.body;
+            const nodeId = res.locals.node.id;
+            const result = await this.nodePastDealsService.updateOrCreatePastDeal(
+                cid, state, size, provider, price, duration, nodeId);
+            res.status(200).json(result)
+        } catch (e) {
+            logger.error(`Error occurred on storing node past deal in controller: ${e.message}`);
+            res.status(500).json({error: "An unknown error occurred."});
+        }
+    }
+}

--- a/src/Controller/Api/NodePastDealsControllerValidation.ts
+++ b/src/Controller/Api/NodePastDealsControllerValidation.ts
@@ -1,0 +1,31 @@
+import {ContainerTypes, ValidatedRequestSchema} from "express-joi-validation";
+import * as Joi from "@hapi/joi";
+
+export interface CreateNodePastDealsRequestSchema extends ValidatedRequestSchema {
+    [ContainerTypes.Body]: {
+        cid: string;
+        state: number;
+        size: string;
+        provider: string;
+        price: string;
+        duration: number;
+        nodeInfo: {
+            url: string;
+            address: string;
+        };
+    };
+}
+
+
+export const CreateNodePastDealsValidationSchema = Joi.object({
+    cid: Joi.string().required(),
+    state: Joi.number().required(),
+    size: Joi.string().regex(/^\d+$/).required(),
+    provider: Joi.string().required(),
+    price: Joi.string().regex(/^\d+$/).required(),
+    duration: Joi.number().required(),
+    nodeInfo: Joi.object({
+        url: Joi.string().required(),
+        address: Joi.string().required()
+    })
+});

--- a/src/Migrations/20200210114133-create-node-past-deals.js
+++ b/src/Migrations/20200210114133-create-node-past-deals.js
@@ -1,0 +1,52 @@
+var sequelize = require("sequelize");
+
+module.exports = {
+    up: function (queryInterface) {
+        return queryInterface.createTable('NodePastDeals', {
+            id: {
+                allowNull: false,
+                autoIncrement: true,
+                primaryKey: true,
+                type: sequelize.INTEGER
+            },
+            cid: {
+                type: sequelize.STRING
+            },
+            state: {
+                type: sequelize.INTEGER
+            },
+            size: {
+                type: sequelize.STRING
+            },
+            provider: {
+                type: sequelize.STRING
+            },
+            price: {
+                type: sequelize.STRING
+            },
+            duration: {
+                type: sequelize.INTEGER
+            },
+            nodeId: {
+                type: sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'Nodes',
+                    key: 'id'
+                },
+                unique: true,
+            },
+            createdAt: {
+                allowNull: false,
+                type: sequelize.DataTypes.DATE
+            },
+            updatedAt: {
+                allowNull: false,
+                type: sequelize.DataTypes.DATE
+            }
+        });
+    },
+    down: function (queryInterface) {
+        return queryInterface.dropTable('NodePastDeals');
+    }
+};

--- a/src/Migrations/20200210114133-create-node-past-deals.js
+++ b/src/Migrations/20200210114133-create-node-past-deals.js
@@ -16,13 +16,13 @@ module.exports = {
                 type: sequelize.INTEGER
             },
             size: {
-                type: sequelize.STRING
+                type: sequelize.BIGINT
             },
             provider: {
                 type: sequelize.STRING
             },
             price: {
-                type: sequelize.STRING
+                type: sequelize.BIGINT
             },
             duration: {
                 type: sequelize.INTEGER

--- a/src/Models/NodePastDeal.ts
+++ b/src/Models/NodePastDeal.ts
@@ -1,0 +1,49 @@
+import {DataTypes, InitOptions, Model, ModelAttributes, Sequelize} from "sequelize";
+import {Node} from "../Models/Node";
+
+export class NodePastDeal extends Model {
+
+    private cid: string;
+    private state: number;
+    private size: string;
+    private provider: string;
+    private price: string;
+    private duration: string;
+    private nodeId: number;
+
+    public static initialize(sequelize: Sequelize) {
+        this.init({
+            cid: {
+                type: DataTypes.STRING(),
+                allowNull: false,
+            },
+            state: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+            },
+            size: {
+                type: DataTypes.STRING(),
+                allowNull: false,
+            },
+            provider: {
+                type: DataTypes.STRING(),
+                allowNull: false,
+            },
+            price: {
+                type: DataTypes.STRING(),
+                allowNull: false,
+            },
+            duration: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+            },
+        } as ModelAttributes,
+            {
+                sequelize: sequelize,
+                tableName: "NodePastDeals",
+                freezeTableName: true,
+            } as InitOptions);
+        this.belongsTo(Node, {foreignKey: "nodeId"});
+        Node.hasOne(NodePastDeal, {foreignKey: "nodeId"});
+    }
+}

--- a/src/Routes/Api.ts
+++ b/src/Routes/Api.ts
@@ -22,6 +22,9 @@ import {CreateMiningRewardsValidationSchema} from "../Controller/Api/MiningRewar
 import {NodeBalanceController} from "../Controller/Api/NodeBalanceController";
 import {CreateNodeBalanceValidationSchema} from "../Controller/Api/NodeBalanceControllerValidation";
 
+import {NodePastDealsController} from "../Controller/Api/NodePastDealsController";
+import {CreateNodePastDealsValidationSchema} from "../Controller/Api/NodePastDealsControllerValidation";
+
 import {passNodeData} from "../Middleware/passingNodeData";
 import {AuthorizeUser} from "../Middleware/Authorization";
 
@@ -33,7 +36,8 @@ export function createApiRoutes(
     userController: UserController,
     nodeGeneralInfoController: NodeGeneralInfoController,
     miningRewardsController: MiningRewardsController,
-    nodeBalanceController: NodeBalanceController
+    nodeBalanceController: NodeBalanceController,
+    nodePastDealsController: NodePastDealsController
 
 ): express.Router {
     const router = express.Router();
@@ -92,6 +96,11 @@ export function createApiRoutes(
         "/user/node/balance",
         [validator.body(CreateNodeBalanceValidationSchema), passNodeData, AuthorizeUser],
         nodeBalanceController.storeNodeBalance.bind(nodeBalanceController));
+
+    router.put(
+        "/user/node/pastdeals",
+        [validator.body(CreateNodePastDealsValidationSchema), passNodeData, AuthorizeUser],
+        nodePastDealsController.updateOrCreatePastDeal.bind(nodePastDealsController));
 
     router.post(
         "/user/register",

--- a/src/Services/Database.ts
+++ b/src/Services/Database.ts
@@ -12,6 +12,7 @@ import {User} from "../Models/User";
 import {NodeGeneralInfo} from "../Models/NodeGeneralInfo";
 import {MiningReward} from "../Models/MiningReward";
 import {NodeBalance} from "../Models/NodeBalance";
+import {NodePastDeal} from "../Models/NodePastDeal";
 
 export class Database {
 
@@ -86,6 +87,7 @@ export class Database {
                 const doneMigrations = await this.migrations.up();
                 logger.info(`${doneMigrations.length} migrations executed successfully`);
             } catch (err) {
+                console.log('err', err)
                 logger.error('Error while trying to run migrations');
             }
         }
@@ -105,6 +107,7 @@ export class Database {
         NodeGeneralInfo.initialize(this.sequelize);
         MiningReward.initialize(this.sequelize);
         NodeBalance.initialize(this.sequelize);
+        NodePastDeal.initialize(this.sequelize);
     }
 }
 

--- a/src/Services/NodePastDealsService.ts
+++ b/src/Services/NodePastDealsService.ts
@@ -1,0 +1,25 @@
+import {NodePastDeal} from "../Models/NodePastDeal";
+
+export class NodePastDealsService {
+
+    public async updateOrCreatePastDeal(
+        cid: string, state: number, size: string, provider: string, price: string, duration: number, nodeId: number) {
+        const pastDeal = await NodePastDeal.findOne({
+            raw: true,
+            where: {
+                nodeId
+            }
+        })
+        if (pastDeal) {
+            const updatedPastDeal = await NodePastDeal.update({cid, state, size, provider, price, duration, nodeId},
+                {
+                    where: {
+                        nodeId
+                    },
+                    returning: true,
+                })
+            return await updatedPastDeal[1]; // returns the updated object, without updates count
+        }
+        return await NodePastDeal.create({cid, state, size, provider, price, duration, nodeId});
+    }
+}

--- a/test/unit/Controllers/PastDealsController.test.ts
+++ b/test/unit/Controllers/PastDealsController.test.ts
@@ -1,0 +1,68 @@
+import sinon from "sinon";
+import {expect} from "chai";
+import {Request, Response} from "express";
+import {NodePastDealsService} from "../../../src/Services/NodePastDealsService";
+import {NodePastDealsController} from "../../../src/Controller/Api/NodePastDealsController";
+import {NodeBalance} from "../../../src/Models/NodeBalance";
+import logger from "../../../src/Services/Logger";
+
+describe("NodePastDealsController", function () {
+    describe('PUT /user/node/pastdeals', () => {
+        const nodePastDealsServiceStub = sinon.createStubInstance(NodePastDealsService);
+        // @ts-ignore
+        nodePastDealsServiceStub.updateOrCreatePastDeal.resolves({
+            "id": 1,
+            "cid": "cid444",
+            "state": 7,
+            "size": "9734204",
+            "provider": "tj0f38",
+            "price": "100000",
+            "duration": 1000,
+            "nodeId": 100,
+        } as unknown as NodeBalance);
+
+        it('should store new node past deal to database', async function () {
+            try {
+                const nodeController = new NodePastDealsController(
+                    nodePastDealsServiceStub as unknown as NodePastDealsService);
+                const response = {} as Response;
+                response.locals = {
+                    node: {id: 100}
+                };
+                response.json = sinon.spy((result) => {
+                    expect(result).to.exist;
+                    expect(result.cid).to.be.equal('cid444');
+                    expect(result.state).to.be.equal(7);
+                    expect(result.size).to.be.equal("9734204");
+                    expect(result.provider).to.be.equal('tj0f38');
+                    expect(result.price).to.be.equal('100000');
+                    expect(result.duration).to.be.equal(1000);
+                    expect(result.nodeId).to.be.equal(100);
+                }) as any;
+
+                response.status = sinon.spy((result) => {
+                    expect(result).to.equal(200)
+                    return response;
+                }) as any;
+
+                await nodeController.updateOrCreatePastDeal({
+                    body: {
+                        "cid": "cid444",
+                        "state": 202,
+                        "size": "9734204",
+                        "provider": "tj0f38",
+                        "price": "100000",
+                        "duration": 1000,
+                        "nodeInfo": {
+                            "address": "address111",
+                            "url": "url111"
+                        }
+                    }
+                } as Request, response)
+            } catch (err) {
+                logger.error('Unexpected error occured: ${err.message}');
+                expect.fail(err);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Created ```PUT``` endpoint ```/user/node/pastdeals``` for storing/updating past deals of a node. 
A deal has  one-to-one relation to a node.  Endpoint recieves: cid, state, size, provider, price, duration and url and address of the node to which it belongs. 