### PR TITLE
Fix/mining rewards filter

### DIFF
--- a/src/Migrations/20200203143917-create-minig-rewards-table.js
+++ b/src/Migrations/20200203143917-create-minig-rewards-table.js
@@ -13,7 +13,7 @@ module.exports = {
                 type: sequelize.STRING
             },
             rewardAmount: {
-                type: sequelize.NUMERIC(200, 100)
+                type: sequelize.NUMERIC(32)
             },
             nodeId: {
                 type: sequelize.INTEGER,

--- a/src/Migrations/20200203143917-create-minig-rewards-table.js
+++ b/src/Migrations/20200203143917-create-minig-rewards-table.js
@@ -13,7 +13,7 @@ module.exports = {
                 type: sequelize.STRING
             },
             rewardAmount: {
-                type: sequelize.STRING
+                type: sequelize.NUMERIC(200, 100)
             },
             nodeId: {
                 type: sequelize.INTEGER,

--- a/src/Models/MiningReward.ts
+++ b/src/Models/MiningReward.ts
@@ -14,7 +14,7 @@ export class MiningReward extends Model {
                 allowNull: false,
             },
             rewardAmount: {
-                type: DataTypes.STRING,
+                type: DataTypes.DECIMAL(32),
                 allowNull: false,
             },
         } as ModelAttributes,

--- a/src/Services/MiningRewardsService.ts
+++ b/src/Services/MiningRewardsService.ts
@@ -1,6 +1,6 @@
 import logger from "./Logger";
 import datebase from "./Database";
-import {QueryTypes} from "sequelize";
+import {filtersSelectQuery} from "../Utils/filterSelectQueryConfig";
 
 import {Node} from "../Models/Node";
 import {MiningReward} from "../Models/MiningReward";
@@ -33,14 +33,6 @@ export class MiningRewardsService {
             and "updatedAt" >= now() - interval :filter
             group by date_trunc(:period, "updatedAt")
             order by "timePeriod" desc;`,
-            {
-                replacements: {
-                    filter: `1 ${filter}`,
-                    nodeId: nodeId,
-                    period: filter == "day" ? "hour" : "day"
-                },
-                type: QueryTypes.SELECT,
-
-            });
+            filtersSelectQuery(nodeId, filter));
     }
 }

--- a/src/Services/MiningRewardsService.ts
+++ b/src/Services/MiningRewardsService.ts
@@ -1,7 +1,6 @@
 import logger from "./Logger";
-import * as moment from "moment";
-import {unitOfTime} from "moment";
-import {Op} from "sequelize";
+import datebase from "./Database";
+import {QueryTypes} from "sequelize";
 
 import {Node} from "../Models/Node";
 import {MiningReward} from "../Models/MiningReward";
@@ -27,16 +26,21 @@ export class MiningRewardsService {
     }
 
     public async fetchMiningRewards(nodeId: number, filter: string) {
-        return await MiningReward.findAll({
-            raw: true,
-            where: {
-                nodeId,
-                updatedAt: {
-                    [Op.gte]:
-                        moment.utc().subtract(1, filter as unitOfTime.Base).format("YYYY-MM-DD HH:MM:ssZZ")
-                }
-            },
-            order: [['updatedAt', 'DESC']]
-        });
+        return await datebase.runQuery<MiningReward>(
+            `select date_trunc(:period, "updatedAt") "timePeriod", sum("rewardAmount") "rewardSum"
+            from "MiningRewards"
+            where "nodeId" = :nodeId
+            and "updatedAt" >= now() - interval :filter
+            group by date_trunc(:period, "updatedAt")
+            order by "timePeriod" desc;`,
+            {
+                replacements: {
+                    filter: `1 ${filter}`,
+                    nodeId: nodeId,
+                    period: filter == "day" ? "hour" : "day"
+                },
+                type: QueryTypes.SELECT,
+
+            });
     }
 }

--- a/src/Utils/filterSelectQueryConfig.ts
+++ b/src/Utils/filterSelectQueryConfig.ts
@@ -1,0 +1,12 @@
+import {QueryTypes, QueryOptionsWithType} from "sequelize";
+
+export function filtersSelectQuery(nodeId: number, filter: string): QueryOptionsWithType<QueryTypes.SELECT> {
+    return {
+        replacements: {
+            filter: `1 ${filter}`,
+            nodeId: nodeId,
+            period: filter == "day" ? "hour" : "day"
+        },
+        type: QueryTypes.SELECT
+    }
+}

--- a/test/unit/Services/MiningRewardsService.test.ts
+++ b/test/unit/Services/MiningRewardsService.test.ts
@@ -2,6 +2,7 @@ import {expect} from "chai";
 import {createSandbox, SinonSandbox} from "sinon";
 import logger from "../../../src/Services/Logger";
 import sinon from "sinon";
+import database from "../../../src/Services/Database";
 import {MiningRewardsService} from "../../../src/Services/MiningRewardsService";
 import {MiningReward} from "../../../src/Models/MiningReward";
 
@@ -14,7 +15,7 @@ describe("MiningRewards", function () {
     beforeEach(function () {
         sandbox = createSandbox();
         miningRewardsService = new MiningRewardsService();
-        miningRewardsFindStub = sinon.stub(MiningReward, "findAll");
+        miningRewardsFindStub = sinon.stub(database, "runQuery");
     });
 
     afterEach(function () {


### PR DESCRIPTION
I had an enlightenment yesterday and figured out that we were using the wrong db column type (it should be NUMERIC(XX,YY) instead of BIGINT. We can change the types to NUMERIC, it supports to 1000 number length from which 500 can be decimal places (tested).

Now the SQL query is very simple and the possibly complicated logic on the backend is avoided.
The query returns the sum of rewardAmounts by the selected filter (by hour for day filter, by day for week/month/year filter).

Resolves #105 Fix mining rewards filter.
