### PR TITLE
remove deploy workflow from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,31 +59,8 @@ jobs:
         root: ./
         paths:
         - ./image.tar
-  deploy:
-    working_directory: ~/app
-    machine:
-      image: circleci/classic:latest
-    steps:
-    - checkout
-    - attach_workspace:
-        at: ./
-    - run:
-        name: Load Docker images
-        command: |
-          set +o pipefail
-          docker load -i ./image.tar || true
-    - run:
-        name: Build production image
-        command: docker build -t final -f Dockerfile.production .
 workflows:
   version: 2
   build-deploy:
     jobs:
-    - build
-    - deploy:
-        requires:
-        - build
-        filters:
-          branches:
-            only:
-            - master
+      - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ FROM node:12.13-alpine as production
 
 WORKDIR /app
 
-COPY --from=0 /usr/app/dist/src /app
-COPY --from=0 /usr/app/package.json /app/
-COPY --from=0 /usr/app/yarn.lock /app/
+COPY --from=dev /usr/app/dist/src /app
+COPY --from=dev /usr/app/package.json /app/
+COPY --from=dev /usr/app/yarn.lock /app/
 
 RUN yarn install --frozen-lockfile --production && yarn cache clean
 


### PR DESCRIPTION
- docker images are automatically built on dockerhub