### PR TITLE
Fix/node balance

### DIFF
--- a/docs/types/nodeBalance.yaml
+++ b/docs/types/nodeBalance.yaml
@@ -27,6 +27,6 @@ responses:
         type: string
         format: date-time
       balanceChange:
-        type: integer
+        type: string
       balanceChangePerc:
         type: string

--- a/src/Services/NodeBalanceService.ts
+++ b/src/Services/NodeBalanceService.ts
@@ -27,18 +27,33 @@ export class NodeBalanceService {
             return {
                 currentBalance: latestRecord,
                 updatedAt: balances[balances.length - 1].updatedAt,
-                balanceChange: earliestRecord.minus(latestRecord),
+                balanceChange: latestRecord.minus(earliestRecord),
                 balanceChangePerc: (latestRecord.minus(earliestRecord))
                     .div(earliestRecord).multipliedBy(100).toFixed(2) + '%'
             }
         } else {
-            return await NodeBalance.findOne({
+            const balance = await NodeBalance.findOne({
                 raw: true,
                 where: {
                     nodeId
                 },
                 order: [['updatedAt', 'DESC']],
             });
+            if (balance) {
+                return {
+                    currentBalance: balance?.balance,
+                    updatedAt: balance?.updatedAt,
+                    balanceChange: "0",
+                    balanceChangePerc: "0.00%"
+                }
+            } else {
+                return {
+                    currentBalance: "0",
+                    updatedAt: moment.utc(),
+                    balanceChange: "0",
+                    balanceChangePerc: "0.00%"
+                }
+            }
         }
     }
 }

--- a/src/Services/NodeBalanceService.ts
+++ b/src/Services/NodeBalanceService.ts
@@ -32,12 +32,13 @@ export class NodeBalanceService {
                     .div(earliestRecord).multipliedBy(100).toFixed(2) + '%'
             }
         } else {
-            return {
-                currentBalance: 0,
-                updatedAt: moment.utc(),
-                balanceChange: 0,
-                balanceChangePerc: 0 + '%'
-            }
+            return await NodeBalance.findOne({
+                raw: true,
+                where: {
+                    nodeId
+                },
+                order: [['updatedAt', 'DESC']],
+            });
         }
     }
 }

--- a/test/e2e/Controller/Api/NodeBalanceTest.test.ts
+++ b/test/e2e/Controller/Api/NodeBalanceTest.test.ts
@@ -1,0 +1,72 @@
+import {expect} from "chai";
+import {describe} from "mocha";
+import request from "supertest";
+import logger from "../../../../src/Services/Logger";
+import {app} from "../../index.test";
+import database from "../../../../src/Services/Database";
+import config from "../../../../src/Config/Config";
+import * as jwt from "jsonwebtoken";
+import * as bcrypt from "bcryptjs";
+import {UserModel} from "../../../../src/Models/UserModel";
+import {Node} from "../../../../src/Models/Node";
+import {NodeBalance} from "../../../../src/Models/NodeBalance";
+
+describe("Node balance controller - fetch node balance test", async () => {
+
+    before(async function () {
+        const password = bcrypt.hashSync('password', 10);
+        // eslint-disable-next-line
+        await UserModel.create({id: 100, email: 'test@test.com', hash_password: `${password}`})
+        await Node.create({
+            id: 5,
+            token: 'token111',
+            url: 'url111',
+            address: 'address111',
+            userId: 100
+        });
+        await NodeBalance.create({
+            id: 10,
+            balance: 43543727524,
+            nodeId: 5
+        });
+        await NodeBalance.create({
+            id: 11,
+            balance: 857386456,
+            nodeId: 5
+        });
+    });
+
+    after(async () => {
+        await database.sequelize.sync({force: true});
+    });
+
+    it("Should return node balance with changes in th elast 24 hours", (done) => {
+        const token = jwt.sign({id: 100}, config.jwtKey, {expiresIn: '24h'})
+
+        try {
+            request(app.server)
+                .get("/api/user/node/balance/5")
+                .set('Authorization', token)
+                .send({
+                    params: {
+                        nodeId: 5,
+                    }
+                })
+                .expect(200)
+                .end((err, res) => {
+                    expect(res).to.exist;
+                    expect(err).to.not.exist;
+                    expect(res.body).to.haveOwnProperty('currentBalance');
+                    expect(res.body).to.haveOwnProperty('updatedAt');
+                    expect(res.body).to.haveOwnProperty('balanceChange');
+                    expect(res.body).to.haveOwnProperty('balanceChangePerc');
+                    done();
+                });
+
+        } catch (err) {
+            logger.error('Unexpected error occured: ${err.message}');
+            expect.fail(err);
+            done();
+        }
+    });
+});

--- a/test/unit/Services/NodeBalance.test.ts
+++ b/test/unit/Services/NodeBalance.test.ts
@@ -9,64 +9,35 @@ describe("NodeBalanceService", function () {
 
     let sandbox: SinonSandbox;
     let nodeBalanceService: NodeBalanceService;
-    let nodeBalanceFindAllStub: SinonStub<any>;
-    let nodeBalanceFindOneStub: SinonStub<any>;
+    let nodeBalanceFindAStub: SinonStub<any>;
 
     beforeEach(function () {
         sandbox = createSandbox();
         nodeBalanceService = new NodeBalanceService();
-        nodeBalanceFindAllStub = sinon.stub(NodeBalance, "findAll");
-        nodeBalanceFindOneStub = sinon.stub(NodeBalance, "findOne");
+        nodeBalanceFindAStub = sinon.stub(NodeBalance, "findAll");
     });
 
     afterEach(function () {
         sandbox.restore();
         logger.silent = false;
-        nodeBalanceFindAllStub.restore();
-        nodeBalanceFindOneStub.restore();
+        nodeBalanceFindAStub.restore();
     });
 
     it("should return node balance with balance changes in the last 24 hours", async () => {
-        nodeBalanceFindAllStub.returns([
-            {
-                "currentBalance": "8537124947501041",
-                "updatedAt": "2020-03-26T06:41:48.000Z",
-                "balanceChange": "0",
-                "balanceChangePerc": "0.00%"
-            }
-        ]);
+        nodeBalanceFindAStub.returns({
+            "currentBalance": "8537124947501041",
+            "updatedAt": "2020-03-26T06:41:48.000Z",
+            "balanceChange": "2353252",
+            "balanceChangePerc": "+23.00%"
+        } as unknown as NodeBalance);
         try {
             const balances = await nodeBalanceService.fetchNodeBalance(1);
 
             expect(balances).to.exist;
             expect(balances).to.haveOwnProperty('currentBalance');
             expect(balances).to.haveOwnProperty('updatedAt');
+            expect(balances).to.haveOwnProperty('balanceChange');
             expect(balances).to.haveOwnProperty('balanceChangePerc');
-
-        } catch (err) {
-            logger.error(`Unexpected error occured: ${err.message}`);
-            expect.fail(err);
-        }
-    });
-
-    it("should return latest node balance outside the last 24 hours", async () => {
-        nodeBalanceFindAllStub.returns([]);
-        nodeBalanceFindOneStub.returns(
-            {
-                "id": 2,
-                "balance": "8537124947501041",
-                "createdAt": "2020-01-13T06:41:48.000Z",
-                "updatedAt": "2020-02-17T06:41:48.000Z",
-                "nodeId": 5
-            } as unknown as NodeBalance);
-        try {
-            const balances = await nodeBalanceService.fetchNodeBalance(5);
-
-            expect(balances).to.exist;
-            expect(balances).to.haveOwnProperty('balance');
-            expect(balances).to.haveOwnProperty('createdAt');
-            expect(balances).to.haveOwnProperty('updatedAt');
-            expect(balances).to.haveOwnProperty('nodeId');
 
         } catch (err) {
             logger.error(`Unexpected error occured: ${err.message}`);

--- a/test/unit/Services/NodeBalance.test.ts
+++ b/test/unit/Services/NodeBalance.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {createSandbox, SinonSandbox} from "sinon";
+import {createSandbox, SinonSandbox, SinonStub} from "sinon";
 import {NodeBalanceService} from "../../../src/Services/NodeBalanceService";
 import logger from "../../../src/Services/Logger";
 import {NodeBalance} from "../../../src/Models/NodeBalance";
@@ -9,35 +9,30 @@ describe("NodeBalanceService", function () {
 
     let sandbox: SinonSandbox;
     let nodeBalanceService: NodeBalanceService;
-    let nodeBalanceFindStub: any;
+    let nodeBalanceFindAllStub: SinonStub<any>;
+    let nodeBalanceFindOneStub: SinonStub<any>;
 
     beforeEach(function () {
         sandbox = createSandbox();
         nodeBalanceService = new NodeBalanceService();
-        nodeBalanceFindStub = sinon.stub(NodeBalance, "findAll");
+        nodeBalanceFindAllStub = sinon.stub(NodeBalance, "findAll");
+        nodeBalanceFindOneStub = sinon.stub(NodeBalance, "findOne");
     });
 
     afterEach(function () {
         sandbox.restore();
         logger.silent = false;
-        nodeBalanceFindStub.restore();
+        nodeBalanceFindAllStub.restore();
+        nodeBalanceFindOneStub.restore();
     });
 
-    it("should return current node balance", async () => {
-        nodeBalanceFindStub.returns([
+    it("should return node balance with balance changes in the last 24 hours", async () => {
+        nodeBalanceFindAllStub.returns([
             {
-                "id": 3,
-                "balance": "8537124947501041",
-                "createdAt": "2020-01-13T06:41:48.000Z",
-                "updatedAt": "2020-02-17T06:41:48.000Z",
-                "nodeId": 1
-            },
-            {
-                "id": 2,
-                "balance": "78974914234696",
-                "createdAt": "2020-02-13T12:02:13.000Z",
-                "updatedAt": "2020-02-17T12:02:13.000Z",
-                "nodeId": 1
+                "currentBalance": "8537124947501041",
+                "updatedAt": "2020-03-26T06:41:48.000Z",
+                "balanceChange": "0",
+                "balanceChangePerc": "0.00%"
             }
         ]);
         try {
@@ -47,6 +42,31 @@ describe("NodeBalanceService", function () {
             expect(balances).to.haveOwnProperty('currentBalance');
             expect(balances).to.haveOwnProperty('updatedAt');
             expect(balances).to.haveOwnProperty('balanceChangePerc');
+
+        } catch (err) {
+            logger.error(`Unexpected error occured: ${err.message}`);
+            expect.fail(err);
+        }
+    });
+
+    it("should return latest node balance outside the last 24 hours", async () => {
+        nodeBalanceFindAllStub.returns([]);
+        nodeBalanceFindOneStub.returns(
+            {
+                "id": 2,
+                "balance": "8537124947501041",
+                "createdAt": "2020-01-13T06:41:48.000Z",
+                "updatedAt": "2020-02-17T06:41:48.000Z",
+                "nodeId": 5
+            } as unknown as NodeBalance);
+        try {
+            const balances = await nodeBalanceService.fetchNodeBalance(5);
+
+            expect(balances).to.exist;
+            expect(balances).to.haveOwnProperty('balance');
+            expect(balances).to.haveOwnProperty('createdAt');
+            expect(balances).to.haveOwnProperty('updatedAt');
+            expect(balances).to.haveOwnProperty('nodeId');
 
         } catch (err) {
             logger.error(`Unexpected error occured: ${err.message}`);


### PR DESCRIPTION
Fixed the response if no node balance records in the last 24 h to return the latest node balance record outside of the last 24 h. 
Added integration test, fixed old unit test and added new unit test for the changes.

Resolves #123 Balance 0 if no report in last 24 hours.