### PR TITLE
Fixed columns types and size between sequelize and migrations

### DIFF
--- a/src/Migrations/20191110125455-create-user.js
+++ b/src/Migrations/20191110125455-create-user.js
@@ -13,7 +13,7 @@ module.exports = {
                 type: sequelize.STRING
             },
             hash_password: {
-                type: sequelize.STRING
+                type: sequelize.STRING(128)
             },
             createdAt: {
                 allowNull: false,

--- a/src/Migrations/20191224091606-create-node.js
+++ b/src/Migrations/20191224091606-create-node.js
@@ -10,13 +10,13 @@ module.exports = {
                 type: sequelize.INTEGER
             },
             url: {
-                type: sequelize.STRING
+                type: sequelize.STRING(128)
             },
             token: {
-                type: sequelize.STRING
+                type: sequelize.STRING(150)
             },
             address: {
-                type: sequelize.STRING
+                type: sequelize.STRING(128)
             },
             userId: {
                 type: sequelize.INTEGER,

--- a/src/Migrations/20200129194920-create-general-miner-info.js
+++ b/src/Migrations/20200129194920-create-general-miner-info.js
@@ -10,7 +10,7 @@ module.exports = {
                 type: sequelize.INTEGER
             },
             version: {
-                type: sequelize.STRING
+                type: sequelize.STRING(25)
             },
             walletAddress: {
                 type: sequelize.STRING

--- a/src/Models/GeneralMinerInfo.ts
+++ b/src/Models/GeneralMinerInfo.ts
@@ -14,7 +14,7 @@ export class GeneralMinerInfo extends Model {
     public static initialize(sequelize: Sequelize) {
         this.init({
             version: {
-                type: DataTypes.STRING(10),
+                type: DataTypes.STRING(25),
                 allowNull: false,
             },
             walletAddress: {
@@ -22,7 +22,7 @@ export class GeneralMinerInfo extends Model {
                 allowNull: false
             },
             sectorSize: {
-                type: DataTypes.STRING,
+                type: DataTypes.BIGINT,
                 allowNull: false,
             },
             numberOfSectors: {
@@ -30,11 +30,11 @@ export class GeneralMinerInfo extends Model {
                 allowNull: false
             },
             minerPower: {
-                type: DataTypes.STRING,
+                type: DataTypes.BIGINT,
                 allowNull: false,
             },
             totalPower: {
-                type: DataTypes.STRING,
+                type: DataTypes.BIGINT,
                 allowNull: false,
             },
         } as ModelAttributes,

--- a/src/Models/Node.ts
+++ b/src/Models/Node.ts
@@ -29,7 +29,7 @@ export class Node extends Model implements INode {
                 allowNull: false,
             },
             token: {
-                type: DataTypes.STRING(128),
+                type: DataTypes.STRING(150),
                 allowNull: false,
             },
             address: {
@@ -41,7 +41,7 @@ export class Node extends Model implements INode {
                 allowNull: true
             },
             description: {
-                type: DataTypes.STRING,
+                type: DataTypes.TEXT,
                 allowNull: true
             },
             hasEnabledNotifications: {

--- a/src/Models/NodeDiskInformation.ts
+++ b/src/Models/NodeDiskInformation.ts
@@ -9,11 +9,11 @@ export class NodeDiskInformation extends Model {
     public static initialize(sequelize: Sequelize) {
         this.init({
             freeSpace: {
-                type: DataTypes.STRING,
+                type: DataTypes.BIGINT,
                 allowNull: false,
             },
             takenSpace: {
-                type: DataTypes.STRING,
+                type: DataTypes.BIGINT,
                 allowNull: false,
             },
         } as ModelAttributes,


### PR DESCRIPTION
Fixed db column types generated by sequelize and migrations.
Fixed `general miner info - version` and `node - token` column size.

Resolves #134 e2e tests locally override existing db column types.